### PR TITLE
fix: reset chunks after message end

### DIFF
--- a/backend/src/openrouter/stream.rs
+++ b/backend/src/openrouter/stream.rs
@@ -74,6 +74,7 @@ impl StreamCompletion {
         }
 
         if let Some(reason) = choice.finish_reason {
+            self.source.close();
             return match reason {
                 raw::FinishReason::Stop => StreamCompletionResp::ResponseToken(content),
                 raw::FinishReason::Length => StreamCompletionResp::ResponseToken(content),

--- a/backend/src/sse/publisher.rs
+++ b/backend/src/sse/publisher.rs
@@ -21,6 +21,18 @@ pub struct Publisher {
 }
 
 impl Publisher {
+    pub fn spawn_scope<T, F, FA>(self, func: FA)
+    where
+        F: Future<Output = Result<T, Error>> + Send + 'static,
+        FA: FnOnce(Arc<Self>) -> F,
+        T: Send + 'static,
+        Self: Send + Sync + 'static,
+    {
+        let self_arc = Arc::new(self);
+        let fut = func(Arc::clone(&self_arc));
+        tokio::spawn(fut);
+    }
+
     pub async fn scope<'a, T, F>(&'a self, func: impl FnOnce(&'a Self) -> F) -> Option<T>
     where
         F: Future<Output = Result<T, Error>>,

--- a/frontend/src/lib/api/chatroom.ts
+++ b/frontend/src/lib/api/chatroom.ts
@@ -57,7 +57,7 @@ export function createRoom(): RawMutationResult<CreateRoomRequest, ChatCreateRes
 				data: {
 					id: chatRes.id,
 					model_id: param.modelId,
-					title: 'new chat'
+					title: 'New Chat'
 				}
 			});
 

--- a/frontend/src/lib/components/message/MessagePagination.svelte
+++ b/frontend/src/lib/components/message/MessagePagination.svelte
@@ -33,6 +33,7 @@
 				}
 			});
 		}
+		chunks = [];
 		isStreaming.set(false);
 	});
 </script>

--- a/frontend/src/lib/components/message/buttons/Reasoning.svelte
+++ b/frontend/src/lib/components/message/buttons/Reasoning.svelte
@@ -22,7 +22,7 @@
 			out:slide={{ duration: 180, axis: 'y' }}
 		>
 			{#each lines as line}
-				<p>{line}</p>
+				<p class="whitespace-pre-wrap">{line}</p>
 			{/each}
 		</div>
 	{/if}


### PR DESCRIPTION
This pull request refactors the backend message creation route to optimize database queries, improve error handling, and streamline message processing logic. It also introduces minor frontend improvements for user experience and code clarity.

### Backend refactoring and optimizations

* Replaced multiple sequential database queries in `backend/src/routes/message/create.rs` with a single `tokio::join!` call to fetch user, chat (with model), and messages (with chunks) concurrently, reducing latency and improving efficiency.
* Refactored error handling to provide more descriptive error contexts and ensure missing resources are handled gracefully in the message creation route.
* Changed the message history construction by moving system prompt injection outside the database query and simplifying the `get_message` function to operate on pre-fetched message/chunk tuples. [[1]](diffhunk://#diff-36b555919cda63e3b6806ae06a2f6398894aadc6405dd11a2a59de70c3e7e8efL299-R319) [[2]](diffhunk://#diff-36b555919cda63e3b6806ae06a2f6398894aadc6405dd11a2a59de70c3e7e8efL156-R190)
* Updated the SSE publishing pattern by introducing a new `spawn_scope` method in `Publisher` (`backend/src/sse/publisher.rs`), replacing the previous `tokio::spawn` usage for improved code clarity and resource management. [[1]](diffhunk://#diff-ce7d438b5448d8062dc3bfc53f1df234c7389aa23282864435820c40a583a568R24-R35) [[2]](diffhunk://#diff-36b555919cda63e3b6806ae06a2f6398894aadc6405dd11a2a59de70c3e7e8efL112-R128)

### Frontend improvements

* Changed chatroom default title to "New Chat" for better presentation (`frontend/src/lib/api/chatroom.ts`).
* Ensured message chunks are cleared when paginating messages to prevent display artifacts (`frontend/src/lib/components/message/MessagePagination.svelte`).
* Improved reasoning message formatting by enabling whitespace preservation (`frontend/src/lib/components/message/buttons/Reasoning.svelte`).

### Miscellaneous

* Updated imports in `backend/src/routes/message/create.rs` to include necessary entities and migration modes for the refactored queries.
* Ensured stream completion properly closes its source when a finish reason is encountered (`backend/src/openrouter/stream.rs`).