### PR TITLE
fix: don't use prefill

### DIFF
--- a/frontend/src/lib/api/message.ts
+++ b/frontend/src/lib/api/message.ts
@@ -22,6 +22,7 @@ import {
 } from './types';
 import { globalCache } from './state/cache';
 import { onDestroy } from 'svelte';
+import { dev } from '$app/environment';
 
 class MessageFetcher implements Fetcher<MessagePaginateRespList> {
 	chatId: number;
@@ -124,7 +125,8 @@ export function startSSE(chatId: number) {
 			id: chatId
 		},
 		onEvent: (res: SseResp) => {
-			console.log('SSE Event:', res);
+			if (dev) console.log('SSE Event:', res);
+
 			SSEHandlers[res.t].forEach((handler) => handler(res.c as any));
 		}
 	});


### PR DESCRIPTION
This pull request improves the handling of model identifiers and message formatting in the backend, and adds a small logging enhancement in the frontend. The main changes include refactoring how model IDs are constructed, ensuring proper message prefill for the OpenRouter API, and making SSE event logging conditional on development mode.

### Backend improvements to model handling and API requests:

* Added a `get_model_id` method to the `Model` struct to centralize and simplify the logic for constructing model identifiers, especially for online models. (`backend/src/openrouter/completion.rs`)
* Updated both the `stream` and `complete` methods to use the new `get_model_id` method instead of manually appending `:online` to model IDs. (`backend/src/openrouter/completion.rs`) [[1]](diffhunk://#diff-b86c36389a553ebd19208e72f474c3b07b112fc9079961463f348da06fb9d226L60-R77) [[2]](diffhunk://#diff-b86c36389a553ebd19208e72f474c3b07b112fc9079961463f348da06fb9d226L82-R113)
* Added logic to both methods to automatically append a blank user message if the last message is from the assistant, following OpenRouter API guidelines for assistant prefill. (`backend/src/openrouter/completion.rs`) [[1]](diffhunk://#diff-b86c36389a553ebd19208e72f474c3b07b112fc9079961463f348da06fb9d226L60-R77) [[2]](diffhunk://#diff-b86c36389a553ebd19208e72f474c3b07b112fc9079961463f348da06fb9d226L82-R113)
* Changed the `messages` parameter in both methods to mutable, allowing for modification when appending the blank user message. (`backend/src/openrouter/completion.rs`)

### Frontend logging improvement:

* Made SSE event logging conditional on development mode by checking the `dev` variable, reducing unnecessary logs in production. (`frontend/src/lib/api/message.ts`) [[1]](diffhunk://#diff-641ad802f2bdbd076296269da1f5ae3bb665e09a574d23add7cda606aecf6496R25) [[2]](diffhunk://#diff-641ad802f2bdbd076296269da1f5ae3bb665e09a574d23add7cda606aecf6496L127-R129)